### PR TITLE
🚧 `WeakDictionary<TKey, TValue>` and dictionary stuff

### DIFF
--- a/Chasm.Collections/CHANGELOG.md
+++ b/Chasm.Collections/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Chasm.Collections Changelog
 
+### v2.4.0
+- ✨ Added `CollectionExtensions.AsEntry(this KeyValuePair<TKey, TValue>)`;
+- ✨ Added `CollectionExtensions.Cast<TKey, TValue>(this DictionaryEntry)`;
+- ✨ Added `CollectionExtensions.ToDictionaryEnumerator<TKey, TValue>(this IEnumerator<KeyValuePair<TKey, TValue>>)`;
+- ✨ Added `sealed class WeakDictionary<TKey, TValue> : IDictionary, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>`;
+- ✨ Added `WeakDictionary<TKey, TValue>()`;
+- ✨ Added `WeakDictionary<TKey, TValue>(IEqualityComparer<TKey>?)`;
+- ✨ Added `WeakDictionary<TKey, TValue>.TryGetValue(TKey, out TValue?)`;
+- ✨ Added `WeakDictionary<TKey, TValue>.Add(TKey, TValue)`;
+- ✨ Added `WeakDictionary<TKey, TValue>.TryAdd(TKey, TValue)`;
+- ✨ Added `WeakDictionary<TKey, TValue>.Remove(TKey)`;
+- ✨ Added `WeakDictionary<TKey, TValue>.Remove(TKey, out TValue?)`;
+- ✨ Added `WeakDictionary<TKey, TValue>.TrimExcess()`;
+- ✨ Added `WeakDictionary<TKey, TValue>.Clear()`;
+- ✨ Added `WeakDictionary<TKey, TValue>.GetEnumerator()`;
+- ✨ Added `WeakDictionary<TKey, TValue>.this[TKey]`;
+- ✨ Added `WeakDictionary<TKey, TValue>.Count`;
+- ✨ Added `WeakDictionary<TKey, TValue>.Keys`;
+- ✨ Added `WeakDictionary<TKey, TValue>.Values`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>()`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>(IEqualityComparer<TKey>?)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.TryGetValue(TKey, out TValue?)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.GetOrAdd(TKey, Func<TKey, TValue>)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.GetOrAdd(TKey, TValue)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.AddOrUpdate(TKey, Func<TKey, TValue, Func<TKey, TValue, TValue>)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.AddOrUpdate(TKey, TValue, Func<TKey, TValue, TValue>)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.TryAdd(TKey, TValue)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.TryUpdate(TKey, TValue, TValue)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.TryRemove(TKey, out TValue?)`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.Clear()`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.GetEnumerator()`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.this[TKey]`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.Count`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.Keys`;
+- ✨ Added `ConcurrentWeakDictionary<TKey, TValue>.Values`;
+
 ### v2.3.1
 - 📝 Added missing XML docs;
 

--- a/Chasm.Collections/CollectionExtensions.cs
+++ b/Chasm.Collections/CollectionExtensions.cs
@@ -79,14 +79,37 @@ namespace Chasm.Collections
 #pragma warning restore CS1573, CS1712
 #endif
 
-        [Pure] public static DictionaryEntry AsEntry<TKey, TValue>(this KeyValuePair<TKey, TValue> entry)
+        /// <summary>
+        ///   <para>Converts the specified key-value <paramref name="pair"/> to an equivalent <see cref="DictionaryEntry"/> struct.</para>
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="pair">The <see cref="KeyValuePair{TKey,TValue}"/> struct to convert.</param>
+        /// <returns>The <see cref="DictionaryEntry"/> struct equivalent to the specified key-value <paramref name="pair"/>.</returns>
+        [Pure] public static DictionaryEntry AsEntry<TKey, TValue>(this KeyValuePair<TKey, TValue> pair)
         {
             // constructor throws on null key only on .NET Framework 1.0 and 1.1
-            return new DictionaryEntry(entry.Key!, entry.Value);
+            return new DictionaryEntry(pair.Key!, pair.Value);
         }
+        /// <summary>
+        ///   <para>Casts the specified dictionary <paramref name="entry"/> to the specified <see cref="KeyValuePair{TKey,TValue}"/> type.</para>
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key to cast to.</typeparam>
+        /// <typeparam name="TValue">The type of the value to cast to.</typeparam>
+        /// <param name="entry">The <see cref="DictionaryEntry"/> to cast to the specified <see cref="KeyValuePair{TKey,TValue}"/> type.</param>
+        /// <returns>The <see cref="KeyValuePair{TKey,TValue}"/> struct equivalent to the specified dictionary <paramref name="entry"/>.</returns>
+        /// <exception cref="InvalidCastException"><paramref name="entry"/>'s key cannot be cast to type <typeparamref name="TKey"/> or its value cannot be cast to type <typeparamref name="TValue"/>.</exception>
         [Pure] public static KeyValuePair<TKey, TValue> Cast<TKey, TValue>(this DictionaryEntry entry)
             => new KeyValuePair<TKey, TValue>((TKey)entry.Key, (TValue)entry.Value!);
 
+        /// <summary>
+        ///   <para>Creates a <see cref="IDictionaryEnumerator"/> from the specified key-value pair <paramref name="enumerator"/>.</para>
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="enumerator">The <see cref="IEnumerator{T}"/> that enumerates <see cref="KeyValuePair{TKey,TValue}"/> items.</param>
+        /// <returns>An <see cref="IEnumerator{T}"/> that enumerates <see cref="DictionaryEntry"/> items.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="enumerator"/> is <see langword="null"/>.</exception>
         [Pure, MustDisposeResource]
         public static IDictionaryEnumerator ToDictionaryEnumerator<TKey, TValue>(
             [HandlesResourceDisposal] this IEnumerator<KeyValuePair<TKey, TValue>> enumerator

--- a/Chasm.Collections/CollectionExtensions.cs
+++ b/Chasm.Collections/CollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Chasm.Collections
@@ -76,6 +77,14 @@ namespace Chasm.Collections
             => (list ?? throw new ArgumentNullException(nameof(list))).Add((t1, t2, t3, t4, t5, t6, t7));
 #pragma warning restore CS1573, CS1712
 #endif
+
+        public static DictionaryEntry AsEntry<TKey, TValue>(this KeyValuePair<TKey, TValue> entry)
+        {
+            // constructor throws on null key only on .NET Framework 1.0 and 1.1
+            return new DictionaryEntry(entry.Key!, entry.Value);
+        }
+        public static KeyValuePair<TKey, TValue> Cast<TKey, TValue>(this DictionaryEntry entry)
+            => new KeyValuePair<TKey, TValue>((TKey)entry.Key, (TValue)entry.Value!);
 
     }
 }

--- a/Chasm.Collections/ConcurrentWeakDictionary.cs
+++ b/Chasm.Collections/ConcurrentWeakDictionary.cs
@@ -1,0 +1,297 @@
+﻿#if NETCOREAPP1_0_OR_GREATER || NETSTANDARD1_1_OR_GREATER || NET45_OR_GREATER
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+#if !NETCOREAPP3_0_OR_GREATER
+#pragma warning disable CS8767
+#endif
+
+namespace Chasm.Collections
+{
+    public sealed class ConcurrentWeakDictionary<TKey, TValue>
+        : IDictionary, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
+        where TKey : notnull where TValue : class
+    {
+        private readonly ConcurrentDictionary<TKey, WeakReference<TValue>> _dict;
+
+        public ConcurrentWeakDictionary()
+            => _dict = [];
+        public ConcurrentWeakDictionary(IEqualityComparer<TKey>? comparer)
+            => _dict = new(comparer);
+
+        [Pure] public bool TryGetValue(TKey key, [NotNullWhen(true)] out TValue? value)
+        {
+            if (_dict.TryGetValue(key, out WeakReference<TValue>? weak))
+                return weak.TryGetTarget(out value);
+            value = default;
+            return false;
+        }
+
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+        {
+            TValue? result = default;
+
+            _dict.AddOrUpdate(
+                key,
+                k => new WeakReference<TValue>(result = valueFactory(k)),
+                (k, weak) =>
+                {
+                    if (!weak.TryGetTarget(out result))
+                        weak.SetTarget(result = valueFactory(k));
+                    return weak;
+                }
+            );
+
+            return result!;
+        }
+        public TValue GetOrAdd(TKey key, TValue value)
+        {
+            // TODO: refactor
+            return GetOrAdd(key, _ => value);
+        }
+
+        public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
+        {
+            TValue? result = default;
+
+            _dict.AddOrUpdate(
+                key,
+                k => new WeakReference<TValue>(result = addValueFactory(k)),
+                (k, weak) =>
+                {
+                    if (weak.TryGetTarget(out TValue? prevValue))
+                    {
+                        result = updateValueFactory(k, prevValue);
+                        if (ReferenceEquals(result, prevValue)) return weak;
+                    }
+                    else
+                    {
+                        result = addValueFactory(k);
+                    }
+                    weak.SetTarget(result);
+                    return weak;
+                }
+            );
+
+            return result!;
+        }
+        public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
+        {
+            // TODO: refactor
+            return AddOrUpdate(key, _ => addValue, updateValueFactory);
+        }
+
+        public bool TryAdd(TKey key, TValue value)
+        {
+            bool added = false;
+
+            _dict.AddOrUpdate(
+                key,
+                _ =>
+                {
+                    added = true;
+                    return new WeakReference<TValue>(value);
+                },
+                (__, weak) =>
+                {
+                    if (!weak.TryGetTarget(out _))
+                    {
+                        added = true;
+                        weak.SetTarget(value);
+                    }
+                    return weak;
+                }
+            );
+
+            return added;
+        }
+        public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue)
+        {
+            try
+            {
+                _dict.AddOrUpdate(
+                    key,
+                    _ => throw new InvalidOperationException(),
+                    (_, weak) =>
+                    {
+                        if (
+                            !weak.TryGetTarget(out TValue? prevValue) ||
+                            !EqualityComparer<TValue>.Default.Equals(prevValue, comparisonValue)
+                        ) throw new InvalidOperationException();
+
+                        if (!ReferenceEquals(prevValue, newValue))
+                            weak.SetTarget(newValue);
+                        return weak;
+                    }
+                );
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+        }
+        public bool TryRemove(TKey key, [NotNullWhen(true)] out TValue? value)
+        {
+            if (_dict.TryRemove(key, out WeakReference<TValue>? weak))
+                return weak.TryGetTarget(out value);
+            value = default;
+            return false;
+        }
+
+        public void Clear()
+            => _dict.Clear();
+
+        [Pure] public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            foreach (KeyValuePair<TKey, WeakReference<TValue>> entry in _dict)
+                if (entry.Value.TryGetTarget(out TValue? value))
+                    yield return new KeyValuePair<TKey, TValue>(entry.Key, value);
+        }
+        [Pure] IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+        [Pure] IDictionaryEnumerator IDictionary.GetEnumerator()
+            => GetEnumerator().ToDictionaryEnumerator();
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                if (TryGetValue(key, out TValue? value)) return value;
+                throw new KeyNotFoundException($"The given key '{key}' was not present in the dictionary.");
+            }
+            set
+            {
+                if (!_dict.TryGetValue(key, out WeakReference<TValue>? weak))
+                    _dict[key] = new WeakReference<TValue>(value);
+                else weak.SetTarget(value);
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                int count = 0;
+                using (IEnumerator<KeyValuePair<TKey, TValue>> enumerator = GetEnumerator())
+                    while (enumerator.MoveNext()) count++;
+                return count;
+            }
+        }
+
+        public ICollection<TKey> Keys
+        {
+            get
+            {
+                List<TKey> results = [];
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    results.Add(entry.Key);
+                return new ReadOnlyCollection<TKey>(results);
+            }
+        }
+        public ICollection<TValue> Values
+        {
+            get
+            {
+                List<TValue> results = [];
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    results.Add(entry.Value);
+                return new ReadOnlyCollection<TValue>(results);
+            }
+        }
+
+        private const string Arg_WrongType = "The value \"{0}\" is not of type \"{1}\" and cannot be used in this generic collection.";
+
+        [Pure] private static TKey CastKeyOrThrow(object key)
+        {
+            if (key is null) throw new ArgumentNullException(nameof(key));
+            if (key is TKey tKey) return tKey;
+            throw new ArgumentException(string.Format(Arg_WrongType, key, typeof(TKey)));
+        }
+        [Pure] private static TValue CastValueOrThrow(object? value)
+        {
+            if (value is null) return null!;
+            return value as TValue ?? throw new ArgumentException(string.Format(Arg_WrongType, value, typeof(TValue)));
+        }
+
+        bool IDictionary.IsFixedSize => false;
+        bool IDictionary.IsReadOnly => false;
+        ICollection IDictionary.Keys => (ICollection)Keys;
+        ICollection IDictionary.Values => (ICollection)Values;
+        [Pure] bool IDictionary.Contains(object key)
+        {
+            if (key is null) throw new ArgumentNullException(nameof(key));
+            return key is TKey tKey && TryGetValue(tKey, out _);
+        }
+        void IDictionary.Add(object key, object? value)
+            => ((IDictionary<TKey, TValue>)this).Add(CastKeyOrThrow(key), CastValueOrThrow(value));
+        void IDictionary.Remove(object key)
+        {
+            if (key is TKey tKey) TryRemove(tKey, out _);
+        }
+        object? IDictionary.this[object key]
+        {
+            get => this[CastKeyOrThrow(key)];
+            set => this[CastKeyOrThrow(key)] = CastValueOrThrow(value);
+        }
+
+        [Pure] bool IDictionary<TKey, TValue>.ContainsKey(TKey key)
+            => TryGetValue(key, out _);
+        void IDictionary<TKey, TValue>.Add(TKey key, TValue value)
+        {
+            if (!TryAdd(key, value))
+                throw new ArgumentException($"An item with the same key has already been added. Key: {key}");
+        }
+        bool IDictionary<TKey, TValue>.Remove(TKey key)
+            => TryRemove(key, out _);
+        [Pure] bool IReadOnlyDictionary<TKey, TValue>.ContainsKey(TKey key)
+            => TryGetValue(key, out _);
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        bool ICollection.IsSynchronized => false;
+        object ICollection.SyncRoot => this;
+        void ICollection.CopyTo(Array array, int index)
+        {
+            if (array is null) throw new ArgumentNullException(nameof(array));
+
+            if (array is KeyValuePair<TKey, TValue>[] pairs)
+                ((ICollection<KeyValuePair<TKey, TValue>>)this).CopyTo(pairs, index);
+            else if (array is DictionaryEntry[] entries)
+            {
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    entries[index++] = new DictionaryEntry(entry.Key, entry.Value);
+            }
+            else if (array is object[] objects)
+            {
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    objects[index++] = entry;
+            }
+            else
+            {
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    array.SetValue(entry, index++);
+            }
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+        [Pure] bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> entry)
+            => TryGetValue(entry.Key, out TValue? value) && EqualityComparer<TValue>.Default.Equals(value, entry.Value);
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> entry)
+            => ((IDictionary<TKey, TValue>)this).Add(entry.Key, entry.Value);
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> entry)
+            => TryRemove(entry.Key, out _);
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+        {
+            foreach (KeyValuePair<TKey, TValue> entry in this)
+                array[index++] = entry;
+        }
+
+    }
+}
+#endif

--- a/Chasm.Collections/ConcurrentWeakDictionary.cs
+++ b/Chasm.Collections/ConcurrentWeakDictionary.cs
@@ -34,6 +34,8 @@ namespace Chasm.Collections
 
         public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
         {
+            if (key is null) throw new ArgumentNullException(nameof(key));
+            if (valueFactory is null) throw new ArgumentNullException(nameof(valueFactory));
             TValue? result = default;
 
             _dict.AddOrUpdate(
@@ -57,6 +59,9 @@ namespace Chasm.Collections
 
         public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
         {
+            if (key is null) throw new ArgumentNullException(nameof(key));
+            if (addValueFactory is null) throw new ArgumentNullException(nameof(addValueFactory));
+            if (updateValueFactory is null) throw new ArgumentNullException(nameof(updateValueFactory));
             TValue? result = default;
 
             _dict.AddOrUpdate(
@@ -288,6 +293,8 @@ namespace Chasm.Collections
             => TryRemove(entry.Key, out _);
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
         {
+            if (array is null) throw new ArgumentNullException(nameof(array));
+
             foreach (KeyValuePair<TKey, TValue> entry in this)
                 array[index++] = entry;
         }

--- a/Chasm.Collections/WeakDictionary.cs
+++ b/Chasm.Collections/WeakDictionary.cs
@@ -12,6 +12,11 @@ using JetBrains.Annotations;
 
 namespace Chasm.Collections
 {
+    /// <summary>
+    ///   <para>Represents a weakly-valued dictionary.</para>
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
     public sealed class WeakDictionary<TKey, TValue>
         : IDictionary, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
         where TKey : notnull where TValue : class

--- a/Chasm.Collections/WeakDictionary.cs
+++ b/Chasm.Collections/WeakDictionary.cs
@@ -216,6 +216,8 @@ namespace Chasm.Collections
             => ((ICollection<KeyValuePair<TKey, TValue>>)this).Contains(entry) && Remove(entry.Key);
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
         {
+            if (array is null) throw new ArgumentNullException(nameof(array));
+
             foreach (KeyValuePair<TKey, TValue> entry in this)
                 array[index++] = entry;
         }

--- a/Chasm.Collections/WeakDictionary.cs
+++ b/Chasm.Collections/WeakDictionary.cs
@@ -1,0 +1,225 @@
+﻿#if NETCOREAPP1_0_OR_GREATER || NETSTANDARD1_0_OR_GREATER || NET45_OR_GREATER
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+#if !NETCOREAPP3_0_OR_GREATER
+#pragma warning disable CS8767
+#endif
+
+namespace Chasm.Collections
+{
+    public sealed class WeakDictionary<TKey, TValue>
+        : IDictionary, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
+        where TKey : notnull where TValue : class
+    {
+        private readonly Dictionary<TKey, WeakReference<TValue>> _dict;
+
+        public WeakDictionary()
+            => _dict = [];
+        public WeakDictionary(IEqualityComparer<TKey>? comparer)
+            => _dict = new(comparer);
+
+        [Pure] public bool TryGetValue(TKey key, [NotNullWhen(true)] out TValue? value)
+        {
+            if (_dict.TryGetValue(key, out WeakReference<TValue>? weak))
+                return weak.TryGetTarget(out value);
+            value = default;
+            return false;
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            if (!TryAdd(key, value))
+                throw new ArgumentException($"An item with the same key has already been added. Key: {key}");
+        }
+        public bool TryAdd(TKey key, TValue value)
+        {
+            if (_dict.TryGetValue(key, out WeakReference<TValue>? weak))
+            {
+                if (weak.TryGetTarget(out _)) return false;
+                weak.SetTarget(value);
+            }
+            else
+            {
+                _dict[key] = new WeakReference<TValue>(value);
+            }
+            return true;
+        }
+
+        public bool Remove(TKey key)
+            => Remove(key, out _);
+        public bool Remove(TKey key, [NotNullWhen(true)] out TValue? value)
+        {
+#if NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            if (_dict.Remove(key, out WeakReference<TValue>? weak))
+                return weak.TryGetTarget(out value);
+#else
+            if (_dict.TryGetValue(key, out WeakReference<TValue>? weak))
+            {
+                _dict.Remove(key);
+                return weak.TryGetTarget(out value);
+            }
+#endif
+            value = default;
+            return false;
+        }
+
+        public void TrimExcess()
+        {
+            foreach (KeyValuePair<TKey, WeakReference<TValue>> entry in _dict)
+            {
+                if (!entry.Value.TryGetTarget(out _))
+                    _dict.Remove(entry.Key);
+            }
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            _dict.TrimExcess();
+#endif
+        }
+        public void Clear()
+            => _dict.Clear();
+
+        [Pure] public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            foreach (KeyValuePair<TKey, WeakReference<TValue>> entry in _dict)
+                if (entry.Value.TryGetTarget(out TValue? value))
+                    yield return new KeyValuePair<TKey, TValue>(entry.Key, value);
+        }
+        [Pure] IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+        [Pure] IDictionaryEnumerator IDictionary.GetEnumerator()
+            => GetEnumerator().ToDictionaryEnumerator();
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                if (TryGetValue(key, out TValue? value)) return value;
+                throw new KeyNotFoundException($"The given key '{key}' was not present in the dictionary.");
+            }
+            set
+            {
+                if (!_dict.TryGetValue(key, out WeakReference<TValue>? weak))
+                    _dict[key] = new WeakReference<TValue>(value);
+                else weak.SetTarget(value);
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                int count = 0;
+                using (IEnumerator<KeyValuePair<TKey, TValue>> enumerator = GetEnumerator())
+                    while (enumerator.MoveNext()) count++;
+                return count;
+            }
+        }
+
+        public ICollection<TKey> Keys
+        {
+            get
+            {
+                List<TKey> results = [];
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    results.Add(entry.Key);
+                return new ReadOnlyCollection<TKey>(results);
+            }
+        }
+        public ICollection<TValue> Values
+        {
+            get
+            {
+                List<TValue> results = [];
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    results.Add(entry.Value);
+                return new ReadOnlyCollection<TValue>(results);
+            }
+        }
+
+        private const string Arg_WrongType = "The value \"{0}\" is not of type \"{1}\" and cannot be used in this generic collection.";
+
+        [Pure] private static TKey CastKeyOrThrow(object key)
+        {
+            if (key is null) throw new ArgumentNullException(nameof(key));
+            if (key is TKey tKey) return tKey;
+            throw new ArgumentException(string.Format(Arg_WrongType, key, typeof(TKey)));
+        }
+        [Pure] private static TValue CastValueOrThrow(object? value)
+        {
+            if (value is null) return null!;
+            return value as TValue ?? throw new ArgumentException(string.Format(Arg_WrongType, value, typeof(TValue)));
+        }
+
+        bool IDictionary.IsFixedSize => false;
+        bool IDictionary.IsReadOnly => false;
+        ICollection IDictionary.Keys => (ICollection)Keys;
+        ICollection IDictionary.Values => (ICollection)Values;
+        [Pure] bool IDictionary.Contains(object key)
+        {
+            if (key is null) throw new ArgumentNullException(nameof(key));
+            return key is TKey tKey && TryGetValue(tKey, out _);
+        }
+        void IDictionary.Add(object key, object? value)
+            => Add(CastKeyOrThrow(key), CastValueOrThrow(value));
+        void IDictionary.Remove(object key)
+        {
+            if (key is TKey tKey) Remove(tKey);
+        }
+        object? IDictionary.this[object key]
+        {
+            get => this[CastKeyOrThrow(key)];
+            set => this[CastKeyOrThrow(key)] = CastValueOrThrow(value);
+        }
+
+        [Pure] bool IDictionary<TKey, TValue>.ContainsKey(TKey key)
+            => TryGetValue(key, out _);
+        [Pure] bool IReadOnlyDictionary<TKey, TValue>.ContainsKey(TKey key)
+            => TryGetValue(key, out _);
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        bool ICollection.IsSynchronized => false;
+        object ICollection.SyncRoot => this;
+        void ICollection.CopyTo(Array array, int index)
+        {
+            if (array is null) throw new ArgumentNullException(nameof(array));
+
+            if (array is KeyValuePair<TKey, TValue>[] pairs)
+                ((ICollection<KeyValuePair<TKey, TValue>>)this).CopyTo(pairs, index);
+            else if (array is DictionaryEntry[] entries)
+            {
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    entries[index++] = new DictionaryEntry(entry.Key, entry.Value);
+            }
+            else if (array is object[] objects)
+            {
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    objects[index++] = entry;
+            }
+            else
+            {
+                foreach (KeyValuePair<TKey, TValue> entry in this)
+                    array.SetValue(entry, index++);
+            }
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
+        [Pure] bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> entry)
+            => TryGetValue(entry.Key, out TValue? value) && EqualityComparer<TValue>.Default.Equals(value, entry.Value);
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> entry)
+            => Add(entry.Key, entry.Value);
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> entry)
+            => ((ICollection<KeyValuePair<TKey, TValue>>)this).Contains(entry) && Remove(entry.Key);
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+        {
+            foreach (KeyValuePair<TKey, TValue> entry in this)
+                array[index++] = entry;
+        }
+
+    }
+}
+#endif

--- a/Chasm.Collections/_Shims.cs
+++ b/Chasm.Collections/_Shims.cs
@@ -1,0 +1,11 @@
+﻿#if !(NETCOREAPP3_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER)
+// ReSharper disable once CheckNamespace
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute(bool returnValue) : Attribute
+    {
+        public bool ReturnValue { get; } = returnValue;
+    }
+}
+#endif


### PR DESCRIPTION
Add a dictionary type that holds weak references to its values (`Dictionary<TKey, WeakReference<TValue>>`, essentially). Consider adding a `ConcurrentWeakDictionary<TKey, TValue>` as well.

May also add some dictionary-related utilities and extensions, for example, extensions for converting `KeyValuePair<TKey, TValue>` to `DictionaryEntry` and back.